### PR TITLE
Support multiple response types

### DIFF
--- a/src/common/httpClient/httpClient.ts
+++ b/src/common/httpClient/httpClient.ts
@@ -1,7 +1,7 @@
 import superagent from 'superagent';
 import { HTTP_TIMEOUT_MS } from './constants';
 import { USER_AGENT } from '../projectConstants';
-import { BasicHttpClient, HttpRequestConfiguration, HttpResult } from './models';
+import { BasicHttpClient, HttpRequestConfiguration, HttpResult, ResponseType } from './models';
 import { serializeWithDatesAsIsoString } from './serialize';
 import { Logger } from 'tslog';
 import { CustomLogger } from '../logging';
@@ -14,6 +14,7 @@ export class HttpClient implements BasicHttpClient {
       .set('Content-Type', 'application/json')
       .set('User-Agent', USER_AGENT)
       .timeout(HTTP_TIMEOUT_MS)
+      .responseType(config.responseType ?? ResponseType.DEFAULT)
       .retry(config.retries);
 
     if (config.customHeaders) {

--- a/src/common/httpClient/models.ts
+++ b/src/common/httpClient/models.ts
@@ -28,3 +28,11 @@ export interface HttpResult<TDto> {
 export interface BasicHttpClient {
   request<TDto>(config: HttpRequestConfiguration): Promise<HttpResult<TDto>>;
 }
+
+export enum ResponseType {
+  TEXT = 'text',
+  BLOB = 'blob',
+  JSON = 'json',
+  DOCUMENT = 'document',
+  ARRAY_BUFFER = 'arraybuffer',
+}

--- a/src/common/httpClient/models.ts
+++ b/src/common/httpClient/models.ts
@@ -30,7 +30,7 @@ export interface BasicHttpClient {
   request<TDto>(config: HttpRequestConfiguration): Promise<HttpResult<TDto>>;
 }
 
-//https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
+// https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
 export enum ResponseType {
   TEXT = 'text',
   BLOB = 'blob',

--- a/src/common/httpClient/models.ts
+++ b/src/common/httpClient/models.ts
@@ -30,6 +30,7 @@ export interface BasicHttpClient {
   request<TDto>(config: HttpRequestConfiguration): Promise<HttpResult<TDto>>;
 }
 
+//https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType
 export enum ResponseType {
   TEXT = 'text',
   BLOB = 'blob',

--- a/src/common/httpClient/models.ts
+++ b/src/common/httpClient/models.ts
@@ -18,6 +18,7 @@ export interface HttpRequestConfiguration {
   params?: QueryParams;
   body?: Record<string, unknown> | string;
   retries?: number;
+  responseType?: ResponseType;
 }
 
 export interface HttpResult<TDto> {
@@ -35,4 +36,5 @@ export enum ResponseType {
   JSON = 'json',
   DOCUMENT = 'document',
   ARRAY_BUFFER = 'arraybuffer',
+  DEFAULT = '',
 }

--- a/src/fft-api/common/fftApiClientService.ts
+++ b/src/fft-api/common/fftApiClientService.ts
@@ -1,5 +1,6 @@
 import { AuthService } from '../auth';
 import { HttpClient, HttpMethod, MAX_RETRIES, QueryParams } from '../../common';
+import { ResponseType } from '../../common/httpClient/models';
 
 export class FftApiClient {
   private readonly baseUrl: string;
@@ -20,27 +21,38 @@ export class FftApiClient {
     );
   }
 
-  public async post<T>(path: string, data?: Record<string, unknown>, params?: QueryParams): Promise<T> {
-    return this.doRequest(HttpMethod.POST, path, data, params);
+  public async post<T>(
+    path: string,
+    data?: Record<string, unknown>,
+    params?: QueryParams,
+    responseType?: ResponseType
+  ): Promise<T> {
+    return this.doRequest(HttpMethod.POST, path, data, params, responseType);
   }
 
-  public async get<T>(path: string, params?: QueryParams): Promise<T> {
-    return this.doRequest(HttpMethod.GET, path, undefined, params);
+  public async get<T>(path: string, params?: QueryParams, responseType?: ResponseType): Promise<T> {
+    return this.doRequest(HttpMethod.GET, path, undefined, params, responseType);
   }
 
-  public async patch<T>(path: string, data: Record<string, unknown>, params?: QueryParams): Promise<T> {
-    return this.doRequest(HttpMethod.PATCH, path, data, params);
+  public async patch<T>(
+    path: string,
+    data: Record<string, unknown>,
+    params?: QueryParams,
+    responseType?: ResponseType
+  ): Promise<T> {
+    return this.doRequest(HttpMethod.PATCH, path, data, params, responseType);
   }
 
-  public async delete<T>(path: string, params?: QueryParams): Promise<T> {
-    return this.doRequest(HttpMethod.DELETE, path, undefined, params);
+  public async delete<T>(path: string, params?: QueryParams, responseType?: ResponseType): Promise<T> {
+    return this.doRequest(HttpMethod.DELETE, path, undefined, params, responseType);
   }
 
   private async doRequest<T>(
     method: HttpMethod,
     path: string,
     data?: Record<string, unknown>,
-    params?: QueryParams
+    params?: QueryParams,
+    responseType?: ResponseType
   ): Promise<T> {
     const token = await this.authService.getToken();
     const customHeaders = { Authorization: `Bearer ${token}` };
@@ -51,6 +63,7 @@ export class FftApiClient {
       params,
       customHeaders,
       retries: method === HttpMethod.GET ? MAX_RETRIES : 0,
+      responseType,
     });
     return result.body as T;
   }


### PR DESCRIPTION
Support multiple return types for http requests as preparation to deal with other data than json (e.g. PDF).
See also the 'Binary' section in the [superagent docs](https://ladjs.github.io/superagent/) and https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType