### PR TITLE
Replace tslog

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,6 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-unused-vars': 'error',
     'no-undef': 'error',
-    'no-console': 'error',
     'no-const-assign': 'error',
   },
   env: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "superagent": "9.0.2",
-        "tslog": "4.9.3"
+        "superagent": "9.0.2"
       },
       "devDependencies": {
         "@babel/preset-env": "7.25.4",
@@ -10985,18 +10984,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/tslog": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.9.3.tgz",
-      "integrity": "sha512-oDWuGVONxhVEBtschLf2cs/Jy8i7h1T+CpdkTNWQgdAF7DhRo2G8vMCgILKe7ojdEkLhICWgI1LYSSKaJsRgcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
-      }
     },
     "node_modules/tsup": {
       "version": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "typescript": "5.5.4"
   },
   "dependencies": {
-    "superagent": "9.0.2",
-    "tslog": "4.9.3"
+    "superagent": "9.0.2"
   },
   "engines": {
     "node": ">=20"

--- a/src/common/httpClient/httpClient.ts
+++ b/src/common/httpClient/httpClient.ts
@@ -3,11 +3,8 @@ import { HTTP_TIMEOUT_MS } from './constants';
 import { USER_AGENT } from '../projectConstants';
 import { BasicHttpClient, HttpRequestConfiguration, HttpResult, ResponseType } from './models';
 import { serializeWithDatesAsIsoString } from './serialize';
-import { Logger } from 'tslog';
-import { CustomLogger } from '../logging';
 
 export class HttpClient implements BasicHttpClient {
-  private readonly logger: Logger<HttpClient> = new CustomLogger<HttpClient>();
   private shouldLogHttpRequestAndResponse: boolean;
   public async request<TDto>(config: HttpRequestConfiguration): Promise<HttpResult<TDto>> {
     const request = superagent(config.method, config.url)
@@ -26,12 +23,11 @@ export class HttpClient implements BasicHttpClient {
     }
 
     if (this.shouldLogHttpRequestAndResponse) {
-      this.logger.debug(`Sending request. Url: ${request.url}, Method: ${request.method}`, [
-        {
-          params: config.params,
-          body: config.body,
-        },
-      ]);
+      console.log(
+        `Sending request. Url: ${request.url}, Method: ${request.method}. Params: ${JSON.stringify(
+          config.params
+        )}, Body: ${JSON.stringify(config.body)}`
+      );
     }
 
     const response = await request
@@ -39,13 +35,10 @@ export class HttpClient implements BasicHttpClient {
       .serialize((body) => JSON.stringify(body, serializeWithDatesAsIsoString));
 
     if (this.shouldLogHttpRequestAndResponse) {
-      this.logger.debug(
-        `Received response. Url: ${request.url}, Method: ${request.method} - Response Status: ${response.statusCode}`,
-        [
-          {
-            body: response.body,
-          },
-        ]
+      console.log(
+        `Received response. Url: ${request.url}, Method: ${request.method} - Response Status: ${
+          response.statusCode
+        }. Body: ${JSON.stringify(response.body)}`
       );
     }
 

--- a/src/common/httpClient/httpClient.ts
+++ b/src/common/httpClient/httpClient.ts
@@ -23,7 +23,7 @@ export class HttpClient implements BasicHttpClient {
     }
 
     if (this.shouldLogHttpRequestAndResponse) {
-      console.log(
+      console.debug(
         `Sending request. Url: ${request.url}, Method: ${request.method}. Params: ${JSON.stringify(
           config.params
         )}, Body: ${JSON.stringify(config.body)}`
@@ -35,7 +35,7 @@ export class HttpClient implements BasicHttpClient {
       .serialize((body) => JSON.stringify(body, serializeWithDatesAsIsoString));
 
     if (this.shouldLogHttpRequestAndResponse) {
-      console.log(
+      console.debug(
         `Received response. Url: ${request.url}, Method: ${request.method} - Response Status: ${
           response.statusCode
         }. Body: ${JSON.stringify(response.body)}`

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,4 +1,3 @@
 export * from './httpClient';
 export * from './projectConstants';
 export * from './utils';
-export * from './logging';

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -1,1 +1,0 @@
-export * from './logger';

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -1,7 +1,0 @@
-import { Logger } from 'tslog';
-
-export class CustomLogger<LogObj> extends Logger<LogObj> {
-  constructor() {
-    super({ type: 'json' });
-  }
-}

--- a/src/fft-api/auth/authService.ts
+++ b/src/fft-api/auth/authService.ts
@@ -1,6 +1,5 @@
 import { RefreshTokenResponse, TokenResponse } from './models';
-import { HttpClient, HttpMethod, MS_PER_SECOND, CustomLogger } from '../../common';
-import { Logger } from 'tslog';
+import { HttpClient, HttpMethod, MS_PER_SECOND } from '../../common';
 
 export interface FftAuthConfig {
   authUrl: string;
@@ -23,7 +22,6 @@ export class AuthService {
   private readonly authRefreshUrl: string;
 
   private static readonly EXPIRY_TOLERANCE_MS = 5000;
-  private readonly logger: Logger<AuthService> = new CustomLogger<AuthService>();
   constructor(private readonly authConfig: FftAuthConfig, private readonly httpClient: HttpClient) {
     this.authLoginUrl = this.authConfig.authUrl;
     this.authRefreshUrl = this.authConfig.refreshUrl;
@@ -51,7 +49,7 @@ export class AuthService {
         this.refreshToken = tokenResponse.body.refreshToken;
         this.expiresAt = this.calcExpiresAt(tokenResponse.body.expiresIn);
       } catch (err) {
-        this.logger.error(`Could not obtain token for '${this.username}': ${err}`);
+        console.error(`Could not obtain token for '${this.username}': ${err}`);
         throw err;
       }
     } else if (new Date().getTime() > this.expiresAt.getTime() - AuthService.EXPIRY_TOLERANCE_MS) {
@@ -69,7 +67,7 @@ export class AuthService {
         this.refreshToken = refreshTokenResponse.body.refresh_token;
         this.expiresAt = this.calcExpiresAt(refreshTokenResponse.body.expires_in);
       } catch (err) {
-        this.logger.error(`Could not refresh token for '${this.username}': ${err}`);
+        console.error(`Could not refresh token for '${this.username}': ${err}`);
         throw err;
       }
     }

--- a/src/fft-api/carrier/fftCarrierService.ts
+++ b/src/fft-api/carrier/fftCarrierService.ts
@@ -1,12 +1,8 @@
-import { Logger } from 'tslog';
-
-import { CustomLogger } from '../../common';
 import { FftApiClient } from '../common';
 import { Carrier, CarrierConfiguration, StrippedCarriers } from '../types';
 
 export class FftCarrierService {
   private readonly path = 'carriers';
-  private readonly logger: Logger<FftCarrierService> = new CustomLogger<FftCarrierService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 

--- a/src/fft-api/external-action/fftExternalActionService.ts
+++ b/src/fft-api/external-action/fftExternalActionService.ts
@@ -1,5 +1,3 @@
-import { CustomLogger } from '../../common';
-import { Logger } from 'tslog';
 import { FftApiClient } from '../common';
 import {
   ExternalAction,
@@ -13,7 +11,6 @@ import { ResponseError } from 'superagent';
 
 export class FftExternalActionService {
   private readonly path = 'externalactions';
-  private readonly logger: Logger<FftExternalActionService> = new CustomLogger<FftExternalActionService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async create(request: ExternalActionForCreation): Promise<ExternalAction> {
@@ -21,7 +18,7 @@ export class FftExternalActionService {
       return await this.apiClient.post<ExternalAction>(this.path, { ...request });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions POST failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -36,7 +33,7 @@ export class FftExternalActionService {
       return await this.apiClient.get<ExternalAction>(`${this.path}/${externalActionId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions get id ${externalActionId} failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -51,7 +48,7 @@ export class FftExternalActionService {
       return await this.apiClient.post<ExternalActionLog>(`${this.path}/${externalActionId}/logs`, { ...logEntry });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions POST Log for ID ${externalActionId} failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -66,7 +63,7 @@ export class FftExternalActionService {
       return await this.apiClient.put<ExternalAction>(`${this.path}/${externalActionId}`, { ...replacement });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions PUT replacement for ID ${externalActionId} failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -81,7 +78,7 @@ export class FftExternalActionService {
       await this.apiClient.delete(`${this.path}/${externalActionId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions DELETE ID ${externalActionId} failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -109,7 +106,7 @@ export class FftExternalActionService {
       return await this.apiClient.get(`${this.path}/${externalActionId}/logs`, params);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT ExternalActions GET Logs for ID ${externalActionId} failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/handover/fftHandoverService.ts
+++ b/src/fft-api/handover/fftHandoverService.ts
@@ -10,12 +10,9 @@ import {
 } from '../types';
 import { FftApiClient } from '../common';
 import ActionEnum = ModifyHandoverjobAction.ActionEnum;
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 
 export class FftHandoverService {
   private readonly path = 'handoverjobs';
-  private readonly logger: Logger<FftHandoverService> = new CustomLogger<FftHandoverService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async findByPickJobRef(pickJobId: string): Promise<StrippedHandoverjobs> {
@@ -25,7 +22,7 @@ export class FftHandoverService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get handover jobs for pickjob id '${pickJobId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -40,7 +37,7 @@ export class FftHandoverService {
       return await this.apiClient.get<Handoverjob>(`${this.path}/${handoverJobId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get handover job with id '${handoverJobId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -65,7 +62,7 @@ export class FftHandoverService {
       return await this.apiClient.patch<Handoverjob>(`${this.path}/${handoverJobId}`, { ...patchObject });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not mark handover job with id '${handoverJobId}' as delivered. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -88,7 +85,7 @@ export class FftHandoverService {
       return handoverJob;
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not cancel handover job with id '${handoverJobId}' and version ${version}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`

--- a/src/fft-api/listing/fftListingService.ts
+++ b/src/fft-api/listing/fftListingService.ts
@@ -1,13 +1,9 @@
-import { Logger } from 'tslog';
 import { ResponseError } from 'superagent';
-
 import { FftApiClient } from '../common';
-import { CustomLogger } from '../../common';
 import { Listing, ListingForReplacement, ModifyListingAction, StrippedListings } from '../types';
 
 export class FftListingService {
   private readonly path = 'listings';
-  private readonly logger: Logger<FftListingService> = new CustomLogger<FftListingService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -19,7 +15,7 @@ export class FftListingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create listing ${listing.tenantArticleId} for facility ${facilityId}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -37,7 +33,7 @@ export class FftListingService {
       if (httpError.status === 404 && relaxed) {
         return undefined;
       }
-      this.logger.error(
+      console.error(
         `Could not fetch listing ${tenantArticleId} for facility ${facilityId}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -54,7 +50,7 @@ export class FftListingService {
       });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get listings for facility ${facilityId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -76,7 +72,7 @@ export class FftListingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update listing ${tenantArticleId} for facility ${facilityId}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -91,7 +87,7 @@ export class FftListingService {
       return await this.apiClient.delete<void>(`facilities/${facilityId}/${this.path}/${tenantArticleId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete listing ${tenantArticleId} for facility ${facilityId}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -106,7 +102,7 @@ export class FftListingService {
       return await this.apiClient.delete<void>(`facilities/${facilityId}/${this.path}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete listings for facility ${facilityId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/loadunit/fftLoadUnitService.ts
+++ b/src/fft-api/loadunit/fftLoadUnitService.ts
@@ -1,13 +1,9 @@
-import { Logger } from 'tslog';
-
 import { FftApiClient } from '../common';
-import { CustomLogger } from '../../common';
 import { LoadUnit, LoadUnits } from '../types';
 import { ResponseError } from 'superagent';
 
 export class FftLoadUnitService {
   private readonly path = 'loadunits';
-  private readonly logger: Logger<FftLoadUnitService> = new CustomLogger<FftLoadUnitService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -17,7 +13,7 @@ export class FftLoadUnitService {
       return loadunits.loadUnits || [];
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get load units for pickjob id '${pickJobRef}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/order/fftOrderService.ts
+++ b/src/fft-api/order/fftOrderService.ts
@@ -8,25 +8,22 @@ import {
   StrippedOrders,
 } from '../types';
 import { FftApiClient } from '../common';
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 
 export class FftOrderService {
   private readonly path = 'orders';
-  private readonly logger: Logger<FftOrderService> = new CustomLogger<FftOrderService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async create(orderForCreation: OrderForCreation): Promise<Order> {
     try {
       const order = await this.apiClient.post<Order>(`${this.path}`, { ...orderForCreation });
-      this.logger.debug(
+      console.debug(
         `Successfully created order with tenantOrderId '${orderForCreation.tenantOrderId}' and order id '${order.id}'`
       );
 
       return order;
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT Order POST with for tenantOrderId '${orderForCreation.tenantOrderId}' failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -46,7 +43,7 @@ export class FftOrderService {
       return order;
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not cancel order with id '${orderId}' and version ${version}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -66,7 +63,7 @@ export class FftOrderService {
       return order;
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not unlock order with id '${orderId}' and version ${version}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -94,7 +91,7 @@ export class FftOrderService {
       return firstOrder;
     }
 
-    this.logger.warn(
+    console.warn(
       `Did not find exactly 1 order with tenantOrderId '${tenantOrderId}' but ${length}, returning first one with id '${firstOrder.id}'`
     );
     return firstOrder;

--- a/src/fft-api/packjob/fftPackJobService.ts
+++ b/src/fft-api/packjob/fftPackJobService.ts
@@ -1,12 +1,10 @@
 import { AbstractModificationAction, PackJob, PackJobForCreation } from '../types';
 import { FftApiClient } from '../common';
 import { ResponseError } from 'superagent';
-import { CustomLogger, QueryParams } from '../../common';
-import { Logger } from 'tslog';
+import { QueryParams } from '../../common';
 
 export class FftPackJobService {
   private readonly path = 'packjobs';
-  private readonly logger: Logger<FftPackJobService> = new CustomLogger<FftPackJobService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async create(packJob: PackJobForCreation): Promise<PackJob> {
@@ -14,7 +12,7 @@ export class FftPackJobService {
       return await this.apiClient.post<PackJob>(`${this.path}`, packJob);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create pack job. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -28,7 +26,7 @@ export class FftPackJobService {
       return await this.apiClient.patch<PackJob>(`${this.path}/${packJob.id}`, { version: packJob.version, actions });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update pack job with id '${packJob.id}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -43,7 +41,7 @@ export class FftPackJobService {
       return await this.apiClient.get<PackJob>(`${this.path}/${packJobId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get pack job with id '${packJobId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -56,7 +54,7 @@ export class FftPackJobService {
       return await this.apiClient.get<{ packJobs: PackJob[] }>(`${this.path}`, params);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get pack jobs. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/parcel/fftParcelService.ts
+++ b/src/fft-api/parcel/fftParcelService.ts
@@ -1,14 +1,11 @@
 import { ResponseError } from 'superagent';
 import { Parcel } from '../types';
 import { FftApiClient } from '../common';
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 import { ResponseType } from '../../common/httpClient/models';
 import { LabelDocument } from './labelDocument';
 
 export class FftParcelService {
   private readonly path = 'parcels';
-  private readonly logger: Logger<FftParcelService> = new CustomLogger<FftParcelService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async findById(parcelId: string): Promise<Parcel> {
@@ -16,7 +13,7 @@ export class FftParcelService {
       return await this.apiClient.get<Parcel>(`${this.path}/${parcelId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get parcel with id '${parcelId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -39,7 +36,7 @@ export class FftParcelService {
       );
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get label ${labelDocument} for parcel with id '${parcelId}'. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`

--- a/src/fft-api/pickjob/fftPickJobService.ts
+++ b/src/fft-api/pickjob/fftPickJobService.ts
@@ -11,12 +11,10 @@ import {
 } from '../types';
 import { FftApiClient, MAX_ARRAY_SIZE } from '../common';
 import { ResponseError } from 'superagent';
-import { isDate, CustomLogger, QueryParams } from '../../common';
-import { Logger } from 'tslog';
+import { isDate, QueryParams } from '../../common';
 
 export class FftPickJobService {
   private readonly path = 'pickjobs';
-  private readonly logger: Logger<FftPickJobService> = new CustomLogger<FftPickJobService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -25,7 +23,7 @@ export class FftPickJobService {
       return await this.apiClient.get<StrippedPickJobs>(this.path, { tenantOrderId });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get pick jobs with tenant order id '${tenantOrderId}'. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -59,7 +57,7 @@ export class FftPickJobService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update pick job with id '${pickJobId}' and version ${version}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -74,7 +72,7 @@ export class FftPickJobService {
       return await this.apiClient.get<PickJob>(`${this.path}/${pickJobId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get pick job with id '${pickJobId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -101,7 +99,7 @@ export class FftPickJobService {
       return await this.apiClient.get<StrippedPickJobs>(this.path, params);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get pick jobs for facility '${id}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -115,7 +113,7 @@ export class FftPickJobService {
       return await this.apiClient.patch<PickJob>(`${this.path}/${pickJob.id}`, { version: pickJob.version, actions });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update pick job with id '${pickJob.id}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -217,7 +215,7 @@ export class FftPickJobService {
       return await this.apiClient.get<StrippedPickJobs>(this.path, queryParams);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Fetching all pickjobs failed with status code ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/process/fftProcessService.ts
+++ b/src/fft-api/process/fftProcessService.ts
@@ -1,12 +1,9 @@
 import { Process } from '../types';
 import { FftApiClient } from '../common';
 import { ResponseError } from 'superagent';
-import { CustomLogger } from '../../common';
-import { Logger } from 'tslog';
 
 export class FftProcessService {
   private readonly path = 'processes';
-  private readonly logger: Logger<FftProcessService> = new CustomLogger<FftProcessService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async getById(processId: string): Promise<Process> {
@@ -14,7 +11,7 @@ export class FftProcessService {
       return await this.apiClient.get<Process>(`${this.path}/${processId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get process with id '${processId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/project/fftProjectService.ts
+++ b/src/fft-api/project/fftProjectService.ts
@@ -1,12 +1,7 @@
-import { Logger } from 'tslog';
-
-import { CustomLogger } from '../../common';
 import { FftApiClient } from '../common';
 import { SupportedEvents, SupportedLocales } from '../types';
 
 export class FftProjectService {
-  private readonly logger: Logger<FftProjectService> = new CustomLogger<FftProjectService>();
-
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async getSupportedLocales(): Promise<string[]> {

--- a/src/fft-api/promising/fftOrderPromisingService.ts
+++ b/src/fft-api/promising/fftOrderPromisingService.ts
@@ -1,5 +1,3 @@
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 import { FftApiClient } from '../common';
 import {
   CheckoutOptionsDeliveryEarliestRequest,
@@ -16,7 +14,6 @@ import { ResponseError } from 'superagent';
 
 export class FftOrderPromisingService {
   private readonly path = 'promises/checkoutoptions';
-  private readonly logger: Logger<FftOrderPromisingService> = new CustomLogger<FftOrderPromisingService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async earliestDelivery(
@@ -28,7 +25,7 @@ export class FftOrderPromisingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT Checkoutoptions Earliest POST failed with status ${httpError.status},  error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -47,7 +44,7 @@ export class FftOrderPromisingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT Checkoutoptions TimePeriod POST failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -66,7 +63,7 @@ export class FftOrderPromisingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT Checkoutoptions TimePoint POST failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -85,7 +82,7 @@ export class FftOrderPromisingService {
       });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `FFT CheckoutOptions POST failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/routing-plan/fftRoutingPlanService.ts
+++ b/src/fft-api/routing-plan/fftRoutingPlanService.ts
@@ -1,12 +1,9 @@
 import { DecisionLog, RoutingPlan, RoutingPlans } from '../types';
 import { FftApiClient } from '../common';
 import { ResponseError } from 'superagent';
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 
 export class FftRoutingPlanService {
   private readonly path = 'routingplans';
-  private readonly logger: Logger<FftRoutingPlanService> = new CustomLogger<FftRoutingPlanService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -15,7 +12,7 @@ export class FftRoutingPlanService {
       return await this.apiClient.get<RoutingPlans>(this.path, { orderRef });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get routing plans for order ref '${orderRef}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -29,7 +26,7 @@ export class FftRoutingPlanService {
       return await this.apiClient.get<RoutingPlan>(`${this.path}/${routingPlanId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get routing plan for ID '${routingPlanId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -43,7 +40,7 @@ export class FftRoutingPlanService {
       return await this.apiClient.get<DecisionLog>(`${this.path}/${routingPlanId}/decisionlogs/${routingRun}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get decision log for routing plan '${routingPlanId}'. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`

--- a/src/fft-api/shipment/fftShipmentService.ts
+++ b/src/fft-api/shipment/fftShipmentService.ts
@@ -1,12 +1,9 @@
 import { ResponseError } from 'superagent';
 import { Parcel, ParcelForCreation, Shipment, StrippedShipments } from '../types';
 import { FftApiClient } from '../common';
-import { Logger } from 'tslog';
-import { CustomLogger } from '../../common';
 
 export class FftShipmentService {
   private readonly path = 'shipments';
-  private readonly logger: Logger<FftShipmentService> = new CustomLogger<FftShipmentService>();
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async findById(shipmentId: string): Promise<Shipment> {
@@ -14,7 +11,7 @@ export class FftShipmentService {
       return await this.apiClient.get<Shipment>(`${this.path}/${shipmentId}`);
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get shipment with id '${shipmentId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -29,7 +26,7 @@ export class FftShipmentService {
       return await this.apiClient.get<StrippedShipments[]>(`${this.path}`, { pickJobRef });
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get shipments for pickJob '${pickJobRef}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -47,7 +44,7 @@ export class FftShipmentService {
       );
     } catch (err) {
       const httpError = err as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create parcel for shipment '${shipmentId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/stock/fftStockService.ts
+++ b/src/fft-api/stock/fftStockService.ts
@@ -1,4 +1,3 @@
-import { Logger } from 'tslog';
 import { FftApiClient, MAX_ARRAY_SIZE } from '../common';
 import {
   FacilityServiceType,
@@ -13,13 +12,11 @@ import {
   StockSummaries,
   StockUpsertOperationResult,
 } from '../types';
-import { CustomLogger, QueryParams } from '../../common';
+import { QueryParams } from '../../common';
 import { ResponseError } from 'superagent';
 
 export class FftStockService {
   private readonly path: string = 'stocks';
-  private readonly logger: Logger<FftStockService> = new CustomLogger<FftStockService>();
-
   constructor(private readonly apiClient: FftApiClient) {}
 
   public async createStock(stockForCreation: StockForCreation): Promise<Stock> {
@@ -27,7 +24,7 @@ export class FftStockService {
       return await this.apiClient.post<Stock>(this.path, { ...stockForCreation });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create stock. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -72,7 +69,7 @@ export class FftStockService {
       return await this.apiClient.get<StockPaginatedResult>(this.path, queryParams);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Fetching all stock failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -87,7 +84,7 @@ export class FftStockService {
       return await this.apiClient.put<StockUpsertOperationResult>(this.path, { ...stocksForUpsert });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not upsert stock. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -102,7 +99,7 @@ export class FftStockService {
       return await this.apiClient.put<Stock>(`${this.path}/${stockId}`, { ...stockForUpdate });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update stock. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -117,7 +114,7 @@ export class FftStockService {
       return await this.apiClient.delete(`${this.path}/${stockId}`);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete stock with id ${stockId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -149,7 +146,7 @@ export class FftStockService {
       return await this.apiClient.post<StockActionResult>(`${this.path}/actions`, action);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete stocks with ids ${stockIds.join()}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -182,7 +179,7 @@ export class FftStockService {
       return await this.apiClient.post<StockActionResult>(`${this.path}/actions`, action);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete stocks in facility ${facilityId} for ${tenantArticleIds.join()}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -214,7 +211,7 @@ export class FftStockService {
       return await this.apiClient.post<StockActionResult>(`${this.path}/actions`, action);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete stocks for locations ${locationIds.join()}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -245,7 +242,7 @@ export class FftStockService {
       return await this.apiClient.post<StockActionResult>(`${this.path}/actions`, action);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not move stock ${fromStockId} to location ${toLocationId}. Failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`
@@ -260,7 +257,7 @@ export class FftStockService {
       return await this.apiClient.get<Stock>(`${this.path}/${stockId}`);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get stock with id '${stockId}'. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -320,7 +317,7 @@ export class FftStockService {
       return await this.apiClient.get<StockSummaries>(`${this.path}/summaries`, queryParams);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Fetching stock summaries failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -370,7 +367,7 @@ export class FftStockService {
       return await this.apiClient.get<StockDistribution>(`articles/${tenantArticleId}/stockdistribution`, queryParams);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Fetching stock distribution for tenantArticleId ${tenantArticleId} failed with status ${
           httpError.status
         }, error: ${httpError.response ? JSON.stringify(httpError.response.body) : ''}`

--- a/src/fft-api/subscription/fftSubscriptionService.ts
+++ b/src/fft-api/subscription/fftSubscriptionService.ts
@@ -1,12 +1,8 @@
-import { Logger } from 'tslog';
 import { FftApiClient } from '../common';
-import { CustomLogger } from '../../common';
 import { Subscription, SubscriptionForCreation, Subscriptions } from '../types';
 
 export class FftSubscriptionService {
   private readonly PATH = 'subscriptions';
-
-  private readonly logger: Logger<FftSubscriptionService> = new CustomLogger<FftSubscriptionService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -14,7 +10,7 @@ export class FftSubscriptionService {
     try {
       return await this.apiClient.get<Subscriptions>(this.PATH, { ...(size && { size: size.toString() }) });
     } catch (err) {
-      this.logger.error(`Getting FFT Subscriptions failed: ${err}`);
+      console.error(`Getting FFT Subscriptions failed: ${err}`);
       throw err;
     }
   }
@@ -23,7 +19,7 @@ export class FftSubscriptionService {
     try {
       return await this.apiClient.post<Subscription>(this.PATH, { ...subscriptionForCreation });
     } catch (err) {
-      this.logger.error(`Creating FFT Subscription '${subscriptionForCreation.name}' failed: ${err}`);
+      console.error(`Creating FFT Subscription '${subscriptionForCreation.name}' failed: ${err}`);
       throw err;
     }
   }
@@ -32,7 +28,7 @@ export class FftSubscriptionService {
     try {
       await this.apiClient.delete(`${this.PATH}/${subscriptionId}`);
     } catch (err) {
-      this.logger.error(`Deleting FFT Subscription '${subscriptionId}' failed: ${err}`);
+      console.error(`Deleting FFT Subscription '${subscriptionId}' failed: ${err}`);
       throw err;
     }
   }

--- a/src/fft-api/tag/fftTagService.ts
+++ b/src/fft-api/tag/fftTagService.ts
@@ -1,13 +1,9 @@
 import { ResponseError } from 'superagent';
-import { Logger } from 'tslog';
 import { FftApiClient } from '../common';
-import { CustomLogger } from '../../common';
 import { AddAllowedValueToTagAction, StrippedTags, Tag, TagForCreation, TagPatchActions } from '../types';
 
 export class FftTagService {
   private readonly PATH = 'tags';
-
-  private readonly logger: Logger<FftTagService> = new CustomLogger<FftTagService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -20,7 +16,7 @@ export class FftTagService {
       return await this.apiClient.post<Tag>(this.PATH, { ...tagForCreation });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create tag. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -34,7 +30,7 @@ export class FftTagService {
       return await this.apiClient.get<Tag>(`${this.PATH}/${id}`);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get tag. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -48,7 +44,7 @@ export class FftTagService {
       return await this.apiClient.get<StrippedTags>(this.PATH, { ...(size && { size: size.toString() }) });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get tags. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -74,7 +70,7 @@ export class FftTagService {
       return await this.apiClient.patch<Tag>(`${this.PATH}/${id}`, { ...tagPatchActions });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update tag ${id}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`

--- a/src/fft-api/zone/fftZoneService.ts
+++ b/src/fft-api/zone/fftZoneService.ts
@@ -1,13 +1,9 @@
 import { ResponseError } from 'superagent';
-import { Logger } from 'tslog';
 import { FftApiClient } from '../common';
-import { CustomLogger } from '../../common';
 import { Zone, ZoneForCreation, ZoneForReplacement } from '../types';
 
 export class FftZoneService {
   private readonly PATH = 'zones';
-
-  private readonly logger: Logger<FftZoneService> = new CustomLogger<FftZoneService>();
 
   constructor(private readonly apiClient: FftApiClient) {}
 
@@ -20,7 +16,7 @@ export class FftZoneService {
       return await this.apiClient.post<Zone>(`facilities/${facilityId}/${this.PATH}`, { ...zoneForCreation });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not create zone. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -36,7 +32,7 @@ export class FftZoneService {
       });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get zones. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -50,7 +46,7 @@ export class FftZoneService {
       return await this.apiClient.get<Zone>(`facilities/${facilityId}/${this.PATH}/${zoneId}`);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not get zone ${zoneId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -72,7 +68,7 @@ export class FftZoneService {
       });
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not update zone ${zoneId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`
@@ -86,7 +82,7 @@ export class FftZoneService {
       return await this.apiClient.delete<void>(`facilities/${facilityId}/${this.PATH}/${zoneId}`);
     } catch (error) {
       const httpError = error as ResponseError;
-      this.logger.error(
+      console.error(
         `Could not delete zone ${zoneId}. Failed with status ${httpError.status}, error: ${
           httpError.response ? JSON.stringify(httpError.response.body) : ''
         }`


### PR DESCRIPTION
This PR contains major changes:

- Changed ESLint Rules: using `console` will no longer result in an error
- Replaced custom logger with console logging
- Removed npm package tslog 