### PR TITLE
feat(con-478): Add force cancellation option to order cancel function

### DIFF
--- a/src/fft-api/order/fftOrderService.ts
+++ b/src/fft-api/order/fftOrderService.ts
@@ -1,7 +1,8 @@
 import { FftApiClient } from '../common';
 import {
   Order,
-  OrderCancelActionParameter, OrderForceCancelActionParameter,
+  OrderCancelActionParameter,
+  OrderForceCancelActionParameter,
   OrderForCreation,
   OrderUnlockActionParameter,
   StrippedOrder,
@@ -29,19 +30,10 @@ export class FftOrderService {
 
   public async cancel(orderId: string, version: number, shouldForceCancellation = false): Promise<Order> {
     try {
-      let order: Order;
-
-      if (shouldForceCancellation) {
-        order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
-          name: OrderForceCancelActionParameter.NameEnum.FORCECANCEL,
-          version,
-        });
-
-        return order;
-      }
-
-      order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
-        name: OrderCancelActionParameter.NameEnum.CANCEL,
+      const order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
+        name: shouldForceCancellation
+          ? OrderForceCancelActionParameter.NameEnum.FORCECANCEL
+          : OrderCancelActionParameter.NameEnum.CANCEL,
         version,
       });
 

--- a/src/fft-api/order/fftOrderService.ts
+++ b/src/fft-api/order/fftOrderService.ts
@@ -27,11 +27,11 @@ export class FftOrderService {
     }
   }
 
-  public async cancel(orderId: string, version: number, force = false): Promise<Order> {
+  public async cancel(orderId: string, version: number, shouldForceCancellation = false): Promise<Order> {
     try {
       let order: Order;
 
-      if (force) {
+      if (shouldForceCancellation) {
         order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
           name: OrderForceCancelActionParameter.NameEnum.FORCECANCEL,
           version,

--- a/src/fft-api/order/fftOrderService.ts
+++ b/src/fft-api/order/fftOrderService.ts
@@ -1,7 +1,7 @@
 import { FftApiClient } from '../common';
 import {
   Order,
-  OrderCancelActionParameter,
+  OrderCancelActionParameter, OrderForceCancelActionParameter,
   OrderForCreation,
   OrderUnlockActionParameter,
   StrippedOrder,
@@ -27,9 +27,20 @@ export class FftOrderService {
     }
   }
 
-  public async cancel(orderId: string, version: number): Promise<Order> {
+  public async cancel(orderId: string, version: number, force = false): Promise<Order> {
     try {
-      const order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
+      let order: Order;
+
+      if (force) {
+        order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
+          name: OrderForceCancelActionParameter.NameEnum.FORCECANCEL,
+          version,
+        });
+
+        return order;
+      }
+
+      order = await this.apiClient.post<Order>(`${this.path}/${orderId}/actions`, {
         name: OrderCancelActionParameter.NameEnum.CANCEL,
         version,
       });


### PR DESCRIPTION
This PR adds the newly introduced force cancellation into the `cancel` function of `FftOrderService`. 