### PR TITLE
respect arrays as url params

### DIFF
--- a/src/common/httpClient/httpClient.ts
+++ b/src/common/httpClient/httpClient.ts
@@ -29,8 +29,15 @@ export class HttpClient implements BasicHttpClient {
 
     if (config.params) {
       Object.entries(config?.params).forEach(([name, value]) => {
-        url.searchParams.append(name, String(value));
+        if ( Array.isArray(value)) {
+          value.forEach((item) => {
+            url.searchParams.append(name, decodeURIComponent(String(item)));
+          });
+        } else {
+          url.searchParams.append(name, decodeURIComponent(String(value)));
+        }
       });
+      url.search = decodeURIComponent(url.search);
     }
 
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
It was not possible to add arrays to (e.g.) the GET /api/facilities call.
To get facilities of all types (MANAGED_FACILITY and SUPPLIER) it's necessary to add two values for param 'type'.
That's now possible with this change.